### PR TITLE
Workaround when creating a FlatDataList with nulled values.

### DIFF
--- a/datumbox-framework-core/src/main/java/com/datumbox/framework/core/common/dataobjects/Dataframe.java
+++ b/datumbox-framework-core/src/main/java/com/datumbox/framework/core/common/dataobjects/Dataframe.java
@@ -670,7 +670,11 @@ public class Dataframe implements Collection<Record>, Copyable<Dataframe>, Savab
         FlatDataList flatDataList = new FlatDataList();
 
         for(Record r : values()) {
-            flatDataList.add(r.getX().get(column));
+            Object v = r.getX().get(column);
+            if (v == null)
+                flatDataList.add(new Double(0.0));
+            else
+                flatDataList.add(v);
         }
 
         return flatDataList;


### PR DESCRIPTION
Sometimes when creating a FlatDataList null values are added to the List, and consequently, when the library tries to retrieve those values it fails with an exception. For example, the method variance() in core.statistics.descriptivestatistics.Descriptive, fails in line 293 (double v = it.next()) when flatDataCollection has some of his values nulled.